### PR TITLE
feat: 헤더 컴포넌트 및 테스트 페이지에 헤더영역  추가

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,16 +1,34 @@
 import { Link } from "react-router-dom";
 import "./header.scss";
+import Button from "./ui/Button";
+import Icon from "./ui/Icon";
 
-export default function Header() {
+function Header() {
   return (
-    <header>
-      <nav>
-        <Link to="/">Home</Link>
-        <Link to="/components1">components1</Link>
-        <Link to="/components2">components2</Link>
-        <Link to="/typo">typo</Link>
-        <Link to="/color">color</Link>
-      </nav>
+    <header className="header">
+      <div className="header__inner">
+        <div className="header__logo">
+          <Link to="/">
+            <Icon name="logo" className="logo-icon" />
+          </Link>
+        </div>
+
+        <nav className="header__nav">
+          <Link to="/">Home</Link>
+          <Link to="/components1">components1</Link>
+          <Link to="/components2">components2</Link>
+          <Link to="/typo">typo</Link>
+          <Link to="/color">color</Link>
+        </nav>
+
+        <div className="header__btn">
+          <Link to="/post">
+            <Button label="롤링 페이퍼 만들기" size="md" variant="outline" />
+          </Link>
+        </div>
+      </div>
     </header>
   );
 }
+
+export default Header;

--- a/src/components/header.scss
+++ b/src/components/header.scss
@@ -1,8 +1,65 @@
-// test : 다 지우고 작업
-header {
-  border-bottom: 1px solid #ededed;
-  nav {
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-bottom: 1px solid var(--c-gray200);
+  background: var(--c-white);
+  height: 64px;
+
+  &__inner {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    max-width: 1200px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+
+  &__logo {
     display: flex;
+    align-items: center;
+
+    .logo-icon {
+      width: 106px;
+      height: auto;
+    }
+  }
+
+  &__nav {
+    display: flex;
+    justify-content: center;
     gap: 16px;
+
+    a {
+      text-decoration: none;
+      @include typo(16, 400);
+    }
+  }
+
+  &__btn {
+    justify-self: end;
+  }
+
+  /* 태블릿 (768px) */
+  @media (max-width: 768px) {
+    &__inner {
+      grid-template-columns: auto auto;
+      padding: 0 24px;
+    }
+
+    &__nav {
+      display: none;
+    }
+  }
+
+  /* 모바일 (360px) */
+  @media (max-width: 360px) {
+    &__inner {
+      padding: 0 18px;
+    }
   }
 }

--- a/src/pages/Test/TestComponents1/index.jsx
+++ b/src/pages/Test/TestComponents1/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Button from "../../../components/ui/Button";
+import Header from "../../../components/Header";
 
 function Components1() {
   return (


### PR DESCRIPTION
**1.Header 컴포넌트 구현**
[경로] 
src/components/ui/Header.jsx 
src/components/ui/Header.scss 

[내용] 
-공통 Header 컴포넌트 구현 및 scss로 디자인 적용
-로고(/), 롤링페이퍼 버튼(/post) 라우팅 연결
-반응형(768, 360) 대응 완료

--

**2.TestComponents1 페이지 수정** 
[경로] 
src/pages/Test/TestComponents1 

[내용] 
-기존 테스트 메뉴와 함께 Header 컴포넌트 적용
