### PR TITLE
feat : post/id, post/id/edit 페이지 반응형

### DIFF
--- a/src/components/modal.scss
+++ b/src/components/modal.scss
@@ -5,8 +5,8 @@
   left: 0;
   right: 0;
   bottom: 0;
-  width: 100vw;
-  height: 100vh;
+  // width: 100vw;
+  // height: 100vh;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   align-items: center;
@@ -102,78 +102,44 @@
   }
 }
 
-/* 반응형 디자인 */
-@media (max-width: 768px) {
-  .modal-backdrop {
-    padding: 16px;
-  }
-
-  .modal-content {
-    width: 100%;
-    max-width: 480px;
-    height: auto;
-    max-height: 90vh;
-  }
-
-  .modal-date {
-    top: 24px;
-    right: 24px;
-  }
-
-  .modal-header {
-    padding: 24px 24px 20px;
-
-    .modal-sender-name {
-      @include typo(18, 400);
-    }
-  }
-
-  .modal-body {
-    padding: 12px 24px;
-
-    .modal-message-content {
-      @include typo(16, 400);
-    }
-  }
-
-  .modal-footer {
-    padding: 20px 24px 32px;
-    justify-content: center;
-  }
-}
-
 @media (max-width: 480px) {
   .modal-content {
     max-width: 100%;
     margin: 0;
-  }
-
-  .modal-date {
-    top: 20px;
-    right: 20px;
+    padding: 30px;
   }
 
   .modal-header {
-    padding: 20px 20px 16px;
-
-    .modal-sender-info {
-      gap: 12px;
-    }
-
     .modal-sender-name {
       @include typo(16, 400);
     }
   }
 
   .modal-body {
-    padding: 12px 20px;
-
     .modal-message-content {
       @include typo(15, 400);
     }
   }
 
   .modal-footer {
-    padding: 16px 20px 24px;
+    .modal-footer-button {
+      width: 100px;
+      padding: 0;
+      @include typo(15, 400);
+    }
+  }
+}
+
+@media (max-width: 400px) {
+  .modal-content {
+    padding: 20px;
+  }
+
+  .modal-footer {
+    .modal-footer-button {
+      width: 80px;
+      padding: 0;
+      @include typo(14, 400);
+    }
   }
 }

--- a/src/components/ui/Reactions.jsx
+++ b/src/components/ui/Reactions.jsx
@@ -5,12 +5,13 @@ import "./Reactions.scss";
  * @param {Object} props
  * @param {Array<{id: string|number, emoji: string, count: number}>} props.reactions - 반응 목록 (**필수**)
  * @param {string} [props.className] - 추가 CSS 클래스 (선택, 기본값: "")
+ * @param {Object} [otherProps] - 기타 추가 props
  */
 
-function Reactions({ reactions = [], className = "" }) {
+function Reactions({ reactions = [], className = "", ...otherProps }) {
   return (
-    <div className={`reactions ${className}`}>
-      <div className="reactions--badges">
+    <div className={`reactions ${className}`} {...otherProps}>
+      <div className="reactions--badges" data-emoji-count={reactions.length}>
         {reactions.map((reaction) => (
           <div key={reaction.id} className="reactions--badge">
             <span className="reactions--emoji">{reaction.emoji}</span>

--- a/src/pages/RollingPaper/components/HeaderService.jsx
+++ b/src/pages/RollingPaper/components/HeaderService.jsx
@@ -33,6 +33,33 @@ function HeaderService({
   const [isEmojiDropdownOpen, setIsEmojiDropdownOpen] = useState(false);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [isShareDropdownOpen, setIsShareDropdownOpen] = useState(false);
+  const [displayedEmojis, setDisplayedEmojis] = useState([]);
+
+  // 화면 크기에 따른 이모지 개수 조정
+  useEffect(() => {
+    const updateDisplayedEmojis = () => {
+      const screenWidth = window.innerWidth;
+      let maxEmojis;
+
+      if (screenWidth <= 1024) {
+        maxEmojis = 6; // 1024px 이하에서는 6개
+      } else {
+        maxEmojis = 8; // PC에서는 8개
+      }
+
+      setDisplayedEmojis(reactionEmojis.slice(0, maxEmojis));
+    };
+
+    // 초기 설정
+    updateDisplayedEmojis();
+
+    // 윈도우 리사이즈 이벤트 리스너
+    window.addEventListener("resize", updateDisplayedEmojis);
+
+    return () => {
+      window.removeEventListener("resize", updateDisplayedEmojis);
+    };
+  }, [reactionEmojis]);
 
   // Ref 관리
   const emojiGroupRef = useRef(null);
@@ -98,9 +125,16 @@ function HeaderService({
   return (
     <div className={`header-service ${className}`}>
       <div className="header-content">
-        <h1>To.{rollingPaper.name}</h1>
+        <h1>To. {rollingPaper.name}</h1>
+        {/* 모바일에서만 보이는 구분선 */}
+        <Divider
+          width={9999}
+          height={1}
+          marginX={0}
+          className="mobile-divider"
+        />
         <div className="header-right-section">
-          <div className="avatar-content">
+          <div className="avatar-content tablet-hide">
             <AvatarGroup
               avatars={rollingPaper.recentMessages?.map((message) => ({
                 id: message.id,
@@ -116,10 +150,8 @@ function HeaderService({
             <p>
               <span>{rollingPaper.messageCount}</span>명이 작성했어요!
             </p>
+            <Divider height={28} marginX={28} className="tablet-hide" />
           </div>
-
-          <Divider height={28} marginX={28} />
-
           <div className="emoji-content" ref={emojiGroupRef}>
             <div className="reactions-container">
               <Reactions reactions={rollingPaper.topReactions} />
@@ -143,7 +175,7 @@ function HeaderService({
             {isEmojiDropdownOpen && (
               <div className="emoji-dropdown-container">
                 <Reactions
-                  reactions={reactionEmojis}
+                  reactions={displayedEmojis}
                   className="dropdown-reactions"
                 />
               </div>
@@ -165,8 +197,8 @@ function HeaderService({
               <div className="emoji-picker-dropdown" ref={emojiPickerRef}>
                 <EmojiPicker
                   onEmojiClick={handleEmojiClick}
-                  width={350}
-                  height={400}
+                  width={300}
+                  height={390}
                   searchPlaceholder="Search"
                   previewConfig={{
                     showPreview: true,
@@ -176,7 +208,7 @@ function HeaderService({
             )}
           </div>
 
-          <Divider height={28} marginX={13} />
+          <Divider height={28} marginX={13} className="share-divider" />
 
           <div className="share-section">
             <Button

--- a/src/pages/RollingPaper/components/HeaderService.scss
+++ b/src/pages/RollingPaper/components/HeaderService.scss
@@ -12,6 +12,11 @@
   z-index: 1000;
   user-select: none;
 
+  /* 모바일 구분선 기본적으로 숨김 */
+  .mobile-divider {
+    display: none;
+  }
+
   .header-content {
     max-width: 1200px;
     margin: 0 auto;
@@ -24,6 +29,14 @@
       @include typo(28, 700);
       color: var(--c-black);
       margin: 0;
+
+      /* 텍스트 오버플로우 처리 */
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex-shrink: 1; /* flex 환경에서 줄어들 수 있도록 */
+      min-width: 0; /* flex item이 줄어들 수 있도록 */
+      max-width: 60%; /* 기본적으로 60% 제한 */
     }
 
     .header-right-section {
@@ -33,12 +46,12 @@
       .avatar-content {
         display: flex;
         align-items: center;
-        gap: 11px;
+        // gap: 11px;
 
         p {
           @include typo(18, 400);
           color: var(--c-gray900);
-          margin: 0;
+          margin-left: 11px;
 
           span {
             font-weight: 700;
@@ -107,64 +120,146 @@
   }
 }
 
-/* 태블릿 (768px 이하) */
-@media (max-width: 768px) {
+/* 태블릿 (1024px 이하) */
+@media (max-width: 1024px) {
   .header-service {
-    height: auto;
+    height: 68px; /* 고정 높이 유지 */
     min-height: 68px;
 
+    /* tablet-hide 클래스 숨기기 */
+    .tablet-hide {
+      display: none !important;
+    }
+
     .header-content {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 16px;
+      flex-direction: row; /* 한 줄로 유지 */
+      align-items: center;
+      justify-content: space-between;
 
       h1 {
         @include typo(24, 700);
+        flex-shrink: 1; /* 제목이 줄어들 수 있도록 변경 */
+        min-width: 0; /* flex item이 줄어들 수 있도록 */
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 50%; /* 최대 50% 너비로 제한 */
       }
 
       .header-right-section {
-        width: 100%;
-        flex-wrap: wrap;
-        gap: 16px;
+        display: flex;
+        align-items: center;
+        flex-shrink: 1;
 
-        .avatar-content p {
-          @include typo(16, 400);
-        }
+        .avatar-content {
+          display: flex;
+          align-items: center;
 
-        .emoji-content .emoji-dropdown-toggle {
-          padding: 6px 10px;
-        }
-
-        .share-section .share-button {
-          padding: 10px 14px;
-          @include typo(14, 400);
+          p {
+            @include typo(16, 400);
+          }
         }
       }
     }
   }
+}
 
-  /* 드롭다운 스타일 */
-  .emoji-dropdown-container {
-    .dropdown-reactions .reactions--badges {
-      max-height: calc(2 * (40px + 6px) - 6px); /* 2줄만 보이기 (6개 아이템) */
-      overflow: hidden;
+@media (max-width: 650px) {
+  .header-service {
+    .header-content {
+      h1 {
+        /* 작은 화면에서 더 적극적인 말줄임표 */
+        max-width: 150px; /* 최대 너비 더 제한 */
+      }
+
+      .header-right-section {
+        .emoji-content {
+          .reactions-container {
+            gap: 4px;
+          }
+
+          .emoji-dropdown-toggle {
+            .arrow-icon {
+              width: 20px;
+              height: 20px;
+              max-width: 20px;
+            }
+          }
+        }
+
+        .emoji-add-section {
+          .emoji-add-button {
+            /* 라벨 텍스트만 숨기기 */
+            .btn__label {
+              display: none;
+            }
+
+            /* 버튼 크기 조정 */
+            padding: 0px 5px;
+            height: 32px;
+            min-width: auto;
+            width: auto;
+          }
+
+          .emoji-picker-dropdown {
+            right: 0;
+          }
+        }
+
+        .share-section {
+          .share-button {
+            padding: 0px 5px;
+            height: 32px;
+          }
+        }
+      }
     }
-  }
-
-  .emoji-picker-dropdown {
-    right: -50px;
-    transform: translateX(-50%);
   }
 }
 
 /* 모바일 (480px 이하) */
 @media (max-width: 480px) {
   .header-service {
+    top: 0; /* 화면 상단에 붙이기 */
     padding: 0 20px;
+    height: 105px; /* 52px + 1px + 52px */
+    min-height: 105px;
+
+    /* 모바일 구분선 보이기 */
+    .mobile-divider {
+      display: block !important;
+      width: calc(100% + 40px) !important; /* 패딩 만큼 확장 */
+      height: 1px !important; /* 높이 1px 고정 */
+      margin-left: -20px !important; /* 패딩 오프셋 */
+      margin-right: -20px !important; /* 패딩 오프셋 */
+    }
 
     .header-content {
+      flex-direction: column; /* 세로 배치 */
+      align-items: stretch; /* 전체 너비 사용 */
+      gap: 0; /* 간격 제거 */
+      padding: 0; /* 패딩 제거 */
+      height: 100%;
+
+      h1 {
+        /* 첫 번째 영역: 52px 높이, 12px 패딩 */
+        height: 52px;
+        padding: 12px 0;
+        margin: 0;
+        @include typo(24, 700);
+        display: flex;
+        align-items: center;
+        max-width: 100%;
+      }
+
       .header-right-section {
-        gap: 12px;
+        /* 두 번째 영역: 52px 높이 */
+        height: 52px;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 8px;
 
         .avatar-content {
           gap: 8px;
@@ -173,38 +268,110 @@
             @include typo(14, 400);
           }
         }
+
+        .emoji-content {
+          .reactions-container {
+            gap: 4px;
+            margin-right: 0px;
+
+            .reactions--badge {
+              padding: 4px 9px;
+            }
+
+            .reactions--emoji {
+              width: 16px;
+              height: 16px;
+            }
+
+            .reactions--count {
+              @include typo(14, 400);
+            }
+          }
+
+          .emoji-dropdown-toggle {
+            padding: 3px;
+
+            .arrow-icon {
+              width: 20px;
+              height: 20px;
+            }
+          }
+        }
+
+        .emoji-add-section {
+          .emoji-add-button {
+            .btn__label {
+              display: none;
+            }
+            padding: 6px 8px;
+            height: 20px;
+            width: 20px;
+            max-width: 20px;
+          }
+
+          .emoji-picker-dropdown {
+            position: absolute;
+            right: -50px;
+          }
+        }
+
+        .share-divider {
+          margin-left: 5px !important;
+          margin-right: 5px !important;
+        }
+
+        .share-section {
+          .share-button {
+            padding: 6px 8px;
+            height: 20px;
+            width: 20px;
+            max-width: 20px;
+          }
+        }
       }
     }
   }
 
   /* 드롭다운 스타일 */
   .emoji-dropdown-container {
-    width: 240px;
-    padding: 8px;
+    padding: 16px !important; /* 모바일에서 패딩 줄이기 */
+    left: 10px !important; /* 왼쪽으로 약간 이동 */
 
-    .dropdown-reactions .reactions--badges {
-      grid-template-columns: repeat(3, 1fr);
-      gap: 4px;
-      max-height: calc(2 * (36px + 4px) - 4px); /* 2줄만 보이기 (6개 아이템) */
-      overflow: hidden;
+    .reactions--badge {
+      padding: 4px 9px;
+    }
+
+    .reactions--emoji {
+      width: 16px;
+      height: 16px;
+    }
+
+    .reactions--count {
+      @include typo(14, 400);
     }
   }
 
   .emoji-picker-dropdown {
-    right: -100px;
-
-    .EmojiPickerReact {
-      width: 300px !important;
-      height: 350px !important;
-    }
+    padding: 16px; /* 이모지 피커도 패딩 줄이기 */
   }
+}
 
-  .share-dropdown {
-    min-width: 120px;
+/* 모바일 (370px 이하) */
+@media (max-width: 370px) {
+  .header-service {
+    .header-content {
+      .header-right-section {
+        .emoji-content {
+          .emoji-dropdown-toggle {
+            padding: 0px;
+          }
+        }
 
-    .share-option {
-      padding: 10px 12px;
-      @include typo(12, 400);
+        .share-divider {
+          margin-left: 2px !important;
+          margin-right: 2px !important;
+        }
+      }
     }
   }
 }
@@ -230,10 +397,22 @@
 
   .dropdown-reactions .reactions--badges {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
     gap: 10px 8px;
     max-height: none; /* 데스크톱: 제한 없음 */
     overflow: visible;
+
+    /* 기본적으로 4열 (8개 이모지용) */
+    grid-template-columns: repeat(4, 1fr);
+
+    /* 6개 이하일 때 3열로 변경 */
+    &[data-emoji-count="6"],
+    &[data-emoji-count="5"],
+    &[data-emoji-count="4"],
+    &[data-emoji-count="3"],
+    &[data-emoji-count="2"],
+    &[data-emoji-count="1"] {
+      grid-template-columns: repeat(3, 1fr);
+    }
   }
 }
 

--- a/src/pages/RollingPaper/components/MessageItem.jsx
+++ b/src/pages/RollingPaper/components/MessageItem.jsx
@@ -86,7 +86,12 @@ function MessageItem({
                   className="message-item--avatar"
                 />
                 <div className="message-item--sender-info">
-                  <span className="message-item--sender-name">
+                  <span
+                    className={
+                      `message-item--sender-name` +
+                      `${isPostEditPage ? "-edit" : ""}`
+                    }
+                  >
                     From.{" "}
                     <span className="message-item--sender-name--highlight">
                       {message.sender}

--- a/src/pages/RollingPaper/components/MessageItem.scss
+++ b/src/pages/RollingPaper/components/MessageItem.scss
@@ -74,10 +74,22 @@
     min-width: 0; // flex item의 overflow 방지
   }
 
-  &--sender-name {
+  &--sender-name,
+  &--sender-name-edit {
     @include typo(20, 400);
     color: var(--c-black);
     line-height: 1.2;
+
+    /* 한 줄 텍스트 말줄임표 */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+    -webkit-box-orient: vertical;
+    word-break: break-all;
+    flex: 1;
+    min-width: 0;
   }
 
   &--sender-name--highlight {
@@ -136,11 +148,24 @@
   @media (max-width: 1248px) {
     width: 100%;
     height: 280px;
+
+    &--sender-name-edit {
+      max-width: 150px;
+    }
   }
 
   // Tablet 스타일 (768px 이하) - 2개 컬럼
-  @media (max-width: 768px) {
+  @media (max-width: 1024px) {
+    width: 100%; /* 컨테이너에 맞게 조정 */
     height: 284px;
+
+    &--sender-name {
+      max-width: 200px; /* 태블릿 크기에 맞게 조정 */
+    }
+
+    &--sender-name-edit {
+      max-width: 160px; /* 태블릿 크기에 맞게 조정 */
+    }
 
     &--text {
       -webkit-line-clamp: 3;
@@ -152,8 +177,58 @@
     }
   }
 
+  @media (max-width: 720px) {
+    &--sender-name-edit {
+      max-width: 140px;
+    }
+  }
+
+  @media (max-width: 660px) {
+    &--sender-name-edit {
+      max-width: 130px;
+    }
+  }
+
+  @media (max-width: 650px) {
+    &--sender-name-edit {
+      max-width: 110px;
+    }
+  }
+
+  @media (max-width: 600px) {
+    &--sender-name-edit {
+      max-width: 95px;
+    }
+  }
+
+  @media (max-width: 575px) {
+    &--sender-name-edit {
+      max-width: 60px;
+    }
+  }
+
+  @media (max-width: 540px) {
+    width: 100%; /* 작은 화면에서도 유연한 크기 */
+
+    &--sender-name {
+      @include typo(18, 400);
+      max-width: 100px; /* 더 작게 조정 */
+    }
+
+    &--sender-name--highlight {
+      @include typo(18, 700);
+    }
+  }
+
+  @media (max-width: 510px) {
+    &--sender-name-edit {
+      max-width: 50px;
+    }
+  }
+
   // Mobile 스타일 (480px 이하) - 1개 컬럼
   @media (max-width: 480px) {
+    width: 100%; /* 모바일에서 전체 너비 사용 */
     height: 230px;
     padding: 20px;
 
@@ -163,11 +238,11 @@
     }
 
     &--sender-name {
-      @include typo(18, 400);
+      max-width: 250px; /* 모바일에서 아주 작게 */
     }
 
-    &--sender-name--highlight {
-      @include typo(16, 400);
+    &--sender-name-edit {
+      max-width: 200px; /* 모바일에서 아주 작게 */
     }
 
     &--text {
@@ -179,7 +254,6 @@
       display: -webkit-box;
       -webkit-box-orient: vertical;
       text-overflow: ellipsis;
-      //margin-bottom: 12px;
     }
 
     &--date {

--- a/src/pages/RollingPaper/components/MessageList.scss
+++ b/src/pages/RollingPaper/components/MessageList.scss
@@ -55,11 +55,25 @@
   }
 
   // Tablet 스타일 (768px 이하) - 2개 컬럼으로 변경
-  @media (max-width: 768px) {
+  @media (max-width: 1024px) {
     &--grid {
       width: 100%;
       gap: 16px;
       grid-template-columns: repeat(2, 1fr);
+      padding-bottom: 80px; /* 하단 고정 버튼을 위한 여백 */
+    }
+
+    &--delete-button {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      top: auto;
+      right: auto;
+      width: calc(100% - 48px);
+      padding: 1.5px 0;
+      max-width: 100%;
+      z-index: 1000;
     }
   }
 
@@ -70,10 +84,12 @@
       padding: 0 20px;
       gap: 16px 0;
       grid-template-columns: 1fr;
+      padding-bottom: 80px; /* 하단 고정 버튼을 위한 여백 */
     }
 
     &--delete-button {
-      right: 20px;
+      /* 1024px 이하 스타일이 상속됨 */
+      width: calc(100% - 40px); /* 모바일에서는 좌우 20px 여백 */
     }
   }
 }

--- a/src/pages/RollingPaper/index.jsx
+++ b/src/pages/RollingPaper/index.jsx
@@ -45,7 +45,7 @@ function Test2() {
       {
         id: 23399,
         recipientId: 12111,
-        sender: "김치영",
+        sender: "Areain Kim",
         profileImageURL: "https://picsum.photos/id/859/100/100",
         relationship: "가족",
         content:
@@ -56,7 +56,7 @@ function Test2() {
       {
         id: 23399,
         recipientId: 12111,
-        sender: "김치영",
+        sender: "Areain Kim",
         profileImageURL: "https://picsum.photos/id/859/100/100",
         relationship: "가족",
         content:

--- a/src/pages/RollingPaper/style.scss
+++ b/src/pages/RollingPaper/style.scss
@@ -50,9 +50,25 @@ body {
     position: relative;
     z-index: 2;
   }
+}
 
-  // // Mobile 스타일 (768px 이하)
-  // @media (max-width: 768px) {
-  //   padding: 40px 0; /* 세로 패딩 유지 */
-  // }
+@media (max-width: 1024px) {
+  .message-list-wrapper {
+    padding-top: 48px; /* 모바일에서 서비스 헤더 공간만 남김 */
+  }
+
+  .top-button {
+    bottom: 70px; /* 하단 고정 버튼을 위한 여백 */
+  }
+}
+
+// Mobile 스타일 (480px 이하)
+@media (max-width: 480px) {
+  .test2-page-wrapper {
+    padding-top: 0; /* 모바일에서 헤더 공간 제거 */
+  }
+
+  .message-list-wrapper {
+    padding-top: 84px; /* 모바일에서 서비스 헤더 공간만 남김 */
+  }
 }


### PR DESCRIPTION
### ✨ 주요 변경사항
- 롤링페이퍼 조회/편집 페이지의 완전한 반응형 디자인 구현
- 다양한 화면 크기에 최적화된 레이아웃 및 컴포넌트 동작

1. HeaderService 컴포넌트 반응형 최적화
- 화면 크기별 이모지 표시 개수 동적 조정 (PC: 8개, 모바일: 6개)
- 모바일 레이아웃: 2줄 구조로 변경 (제목 + 구분선 + 액션 영역)
- 텍스트 오버플로우: 긴 제목에 대한 말줄임표 처리

2. MessageList 컴포넌트 그리드 시스템 개선
- PC: 3열 그리드 (1200px 최대 너비)
- 태블릿 (1024px 이하): 2열 그리드
- 모바일 (480px 이하): 1열 그리드
- 삭제 버튼 위치: 태블릿/모바일에서 하단 고정 버튼으로 변경

3. MessageItem 카드 반응형 최적화
- 카드 크기: 화면 크기에 따른 동적 조정
- 텍스트 오버플로우: 발신자 이름에 대한 말줄임표 구현
- 편집 모드: 삭제 버튼 추가 및 반응형 동작

4. Modal 컴포넌트 반응형 개선
- 모바일 대응: 480px, 400px 브레이크포인트 추가
- 패딩 및 폰트 크기: 화면 크기별 최적화
- 버튼 크기: 반응형 크기 조정

5. Reactions 컴포넌트 개선
- 이모지 개수 감지: data-emoji-count 속성 추가
- 그리드 레이아웃: 이모지 개수에 따른 동적 열 조정
